### PR TITLE
Close some issues

### DIFF
--- a/fontawesome.sty
+++ b/fontawesome.sty
@@ -43,7 +43,6 @@
 
 % definition of \FA as a shortcut to load the Font Awesome font
 \newfontfamily{\FA}[
-Path = fonts/fontawesome/opentype/ ,
 Scale = 0.85 ,
 SmallCapsFont = *
 ]{FontAwesome}

--- a/resume.cls
+++ b/resume.cls
@@ -14,7 +14,7 @@
 \RequirePackage{url}
 \urlstyle{tt}
 % use fontawesome
-\RequirePackage{fontawesome}
+\RequirePackage{fontawesome5}
 % use xcolor for customizing color
 %\RequirePackage[usenames,dvipsnames]{xcolor}
 % loading fonts

--- a/resume.cls
+++ b/resume.cls
@@ -21,7 +21,6 @@
 \RequirePackage{fontspec}
 % Main document font
 \setmainfont[
-  Path = fonts/Main/ ,
   Extension = .otf ,
   UprightFont = *-regular ,
   BoldFont = *-bold ,

--- a/resume_photo.tex
+++ b/resume_photo.tex
@@ -5,6 +5,7 @@
 \usepackage{tabu}
 \usepackage{multirow}
 \usepackage{progressbar}
+\usepackage{hologo}
 %\usepackage{zh_CN-Adobefonts_external} % Simplified Chinese Support using external fonts (./fonts/zh_CN-Adobe/)
 %\usepackage{zh_CN-Adobefonts_internal} % Simplified Chinese Support using system fonts
 
@@ -54,7 +55,7 @@ Brief introduction: xxx
 An elegant \LaTeX\ résumé template, https://github.com/billryan/resume
 \begin{itemize}
   \item Easy to be further customized or extended
-  \item Full support for unicode characters (e.g. CJK) with \XeLaTeX\
+  \item Full support for unicode characters (e.g. CJK) with \hologo{XeLaTeX}\
   \item FontAwesome 4.5.0 support
 \end{itemize}
 


### PR DESCRIPTION
#52 and #54:
i recommend create another branch to handle overloaf temporarily. and other user use master. the problem that overloaf cannot support relative path, should be reported to developer of overloaf.

#53 
not all latex engine define `\XeLaTeX` by default. hologo can make this command cross all latex engine.

thanks.