### PR TITLE
Add Chinese photo resume template

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ xelatex myresume-zh_CN
 想自己添加新的宏的可以先看看 [How to write a LaTeX class file and design your own CV (Part 1) - ShareLaTeX](https://www.sharelatex.com/blog/2011/03/27/how-to-write-a-latex-class-file-and-design-your-own-cv.html) 和 [How to write a LaTeX class file and design your own CV (Part 2) - ShareLaTeX](https://www.sharelatex.com/blog/2013/06/28/how-to-write-a-latex-class-file-and-design-your-own-cv.html) 了解下该模板的简单背景。
 
 - `\name`: 姓名
-- `\photoHeader`: 带照片模板的页眉，参数为姓名和联系信息，默认使用 `avatar.jpg`
+- `\photoHeader`: `resume-zh_CN_photo.tex` 中定义的带照片页眉，参数为姓名和联系信息，默认使用 `avatar`
 - `\email`: 邮箱
 - `\linkedin`: LinkedIn
 - `\basicInfo`: 联系信息, 按需加入

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Hit branch [master](https://github.com/billryan/resume/tree/master) if you wanna
 感谢万能的『云计算』，`\LaTeX` 编译也可以放到云端了！使用这种方法无需在本机安装诸如 `CTeX/TeXlive/MacTeX` 等发行版，网站上还能有历史版本记录，十分方便！最简单的方法，浏览器中打开 [模板链接](https://www.overleaf.com/latex/templates/bill-ryans-elegant-latex-resume/xcqmhktmzmsw), 按需更改自己的名字和联系方式等。
 在线预览时需要注意 Overleaf 自带的 PDF 阅读器对中文支持不太好(可能会显示乱码)，这时在编辑界面的左侧菜单选择使用 native 阅读器即可。
 
-中文模板的文件为 `resume-zh_CN.tex`, 英文模板的文件为 `resume.tex`, 带照片的模板文件为 `resume_photo.tex`.
+中文模板的文件为 `resume-zh_CN.tex`, 带照片的中文模板文件为 `resume-zh_CN_photo.tex`, 英文模板的文件为 `resume.tex`, 带照片的英文模板文件为 `resume_photo.tex`.
 
 ### latexonline.cc
 
@@ -59,6 +59,7 @@ Hit branch [master](https://github.com/billryan/resume/tree/master) if you wanna
 xelatex resume.tex % 编译英文简历
 xelatex resume_photo.tex % 编译带照片的简历
 xelatex resume-zh_CN.tex % 编译中文简历
+xelatex resume-zh_CN_photo.tex % 编译带照片的中文简历
 ```
 
 ### 中英文双语支持
@@ -77,6 +78,7 @@ xelatex resume-zh_CN.tex % 编译中文简历
 
 英文模板范例见 <https://github.com/billryan/resume/blob/zh_CN/resume.tex> 
 中文模板范例见 <https://github.com/billryan/resume/blob/zh_CN/resume-zh_CN.tex>
+带照片的中文模板范例见 <https://github.com/billryan/resume/blob/zh_CN/resume-zh_CN_photo.tex>
 
 中文模板与英文模板的区别仅有两行——使用中文时仅需反注释以下两行，模板中已默认启用，第一次编译时耗时相对较长(引入了外部中文字型)，耐心等待下。
 
@@ -112,6 +114,7 @@ xelatex myresume-zh_CN
 想自己添加新的宏的可以先看看 [How to write a LaTeX class file and design your own CV (Part 1) - ShareLaTeX](https://www.sharelatex.com/blog/2011/03/27/how-to-write-a-latex-class-file-and-design-your-own-cv.html) 和 [How to write a LaTeX class file and design your own CV (Part 2) - ShareLaTeX](https://www.sharelatex.com/blog/2013/06/28/how-to-write-a-latex-class-file-and-design-your-own-cv.html) 了解下该模板的简单背景。
 
 - `\name`: 姓名
+- `\photoHeader`: 带照片模板的页眉，参数为姓名和联系信息，默认使用 `avatar.jpg`
 - `\email`: 邮箱
 - `\linkedin`: LinkedIn
 - `\basicInfo`: 联系信息, 按需加入

--- a/resume-zh_CN_photo.tex
+++ b/resume-zh_CN_photo.tex
@@ -1,0 +1,108 @@
+% !TEX TS-program = xelatex
+% !TEX encoding = UTF-8 Unicode
+% !Mode:: "TeX:UTF-8"
+
+\documentclass{resume}
+\usepackage{graphicx}
+\usepackage{zh_CN-Adobefonts_external} % Simplified Chinese Support using external fonts (./fonts/zh_CN-Adobe/)
+% \usepackage{NotoSansSC_external}
+% \usepackage{NotoSerifCJKsc_external}
+% \usepackage{zh_CN-Adobefonts_internal} % Simplified Chinese Support using system fonts
+\usepackage{linespacing_fix} % disable extra space before next section
+\usepackage{cite}
+
+\titlespacing*{\section}{0cm}{*1.2}{*1.0}
+\titlespacing*{\subsection}{0cm}{*1.2}{*0.4}
+
+\newcommand{\photoHeader}[2]{%
+  \noindent
+  \begin{tabular*}{\textwidth}{@{}p{0.12\textwidth}@{\extracolsep{\fill}}c@{\extracolsep{\fill}}p{0.12\textwidth}@{}}
+    &
+    \begin{minipage}[t]{0.74\textwidth}
+      \vspace{0pt}
+      \centering
+      {\LARGE\bfseries #1}\par
+      \vspace{0.6ex}
+      {\sffamily\large #2}
+    \end{minipage}
+    &
+    \begin{minipage}[t]{0.12\textwidth}
+      \vspace{0pt}
+      \raggedleft\includegraphics[width=0.78in,height=1.02in]{avatar.jpg}
+    \end{minipage}
+  \end{tabular*}
+  \vspace{-4.5ex}
+}
+
+\begin{document}
+\pagenumbering{gobble} % suppress displaying page number
+
+\photoHeader
+  {你的大名}
+  {\email{yuanbin2014@gmail.com} \textperiodcentered\ 
+  \phone{(+86) 131-221-87xxx}\par
+  \linkedin[billryan8]{https://www.linkedin.com/in/billryan8}}
+
+\section{\faGraduationCap\  教育背景}
+\datedsubsection{\textbf{上海交通大学}, 上海}{2013 -- 至今}
+\textit{在读硕士研究生}\ 信息与通信工程, 预计 2016 年 3 月毕业
+\datedsubsection{\textbf{西安电子科技大学}, 西安, 陕西}{2009 -- 2013}
+\textit{学士}\ 通信工程
+
+\section{\faUsers\ 实习/项目经历}
+\datedsubsection{\textbf{黑科技公司} 上海}{2015年3月 -- 2015年5月}
+\role{实习}{经理: 高富帅}
+xxx后端开发
+\begin{itemize}
+  \item 实现了 xxx 特性
+  \item 后台资源占用率减少8\%
+  \item xxx
+\end{itemize}
+
+\datedsubsection{\textbf{分布式科学上网姿势}}{2014年6月 -- 至今}
+\role{Golang, Linux}{个人项目，和富帅糕合作开发}
+\begin{onehalfspacing}
+分布式负载均衡科学上网姿势, https://github.com/cyfdecyf/cow
+\begin{itemize}
+  \item 修复了连接未正常关闭导致文件描述符耗尽的 bug
+  \item 使用Chord 哈希 URL, 实现稳定可靠地分流
+  \item xxx (尽量使用量化的客观结果)
+\end{itemize}
+\end{onehalfspacing}
+
+\datedsubsection{\textbf{\LaTeX\ 简历模板}}{2015 年5月 -- 至今}
+\role{\LaTeX, Python}{个人项目}
+\begin{onehalfspacing}
+优雅的 \LaTeX\ 简历模板, https://github.com/billryan/resume
+\begin{itemize}
+  \item 容易定制和扩展
+  \item 完善的 Unicode 字体支持，使用 \XeLaTeX\ 编译
+  \item 支持 FontAwesome 4.5.0
+\end{itemize}
+\end{onehalfspacing}
+
+\section{\faCogs\ IT 技能}
+% increase linespacing [parsep=0.5ex]
+\begin{itemize}[parsep=0.5ex]
+  \item 编程语言: C == Python > C++ > Java
+  \item 平台: Linux
+  \item 开发: xxx
+\end{itemize}
+
+\section{\faHeartO\ 获奖情况}
+\datedline{\textit{第一名}, xxx 比赛}{2013 年6 月}
+\datedline{其他奖项}{2015}
+
+\section{\faInfo\ 其他}
+% increase linespacing [parsep=0.5ex]
+\begin{itemize}[parsep=0.5ex]
+  \item 技术博客: http://blog.yours.me
+  \item GitHub: https://github.com/username
+  \item 语言: 英语 - 熟练(TOEFL xxx)
+\end{itemize}
+
+%% Reference
+%\newpage
+%\bibliographystyle{IEEETran}
+%\bibliography{mycite}
+\end{document}

--- a/resume-zh_CN_photo.tex
+++ b/resume-zh_CN_photo.tex
@@ -28,7 +28,7 @@
     &
     \begin{minipage}[t]{0.12\textwidth}
       \vspace{0pt}
-      \raggedleft\includegraphics[width=0.78in,height=1.02in]{avatar.jpg}
+      \raggedleft\includegraphics[width=0.78in,height=1.02in,keepaspectratio]{avatar}
     \end{minipage}
   \end{tabular*}
   \vspace{-4.5ex}


### PR DESCRIPTION
## Summary
- Add a Simplified Chinese resume template with photo header support
- Document the new template and xelatex build command in README

## Test
- xelatex -interaction=nonstopmode -halt-on-error -output-directory=/tmp/resume-build resume-zh_CN_photo.tex